### PR TITLE
Add extended visualizations

### DIFF
--- a/explorasi_visualisasi.ipynb
+++ b/explorasi_visualisasi.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv('cluster_sentiment_output_clean.csv')\n",
+    "df = pd.read_csv('cluster_sentiment_output.csv')\n",
     "print(df.shape)\n",
     "df.head()"
    ]
@@ -137,6 +137,111 @@
     "plt.ylabel('Frekuensi')\n",
     "plt.title('Distribusi Sentiment')\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dccdd45f",
+   "metadata": {},
+   "source": [
+    "## Korelasi Antar Pertanyaan Likert"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3563866a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Korelasi antar pertanyaan Likert\n",
+    "likert_cols = [c for c in df.columns if '[' in c and 'Pernah' not in c]\n",
+    "likert_df = df[likert_cols].apply(pd.to_numeric, errors='coerce')\n",
+    "plt.figure(figsize=(12,10))\n",
+    "sns.heatmap(likert_df.corr(), cmap='coolwarm', center=0)\n",
+    "plt.title('Korelasi Pertanyaan Likert')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df811e5a",
+   "metadata": {},
+   "source": [
+    "## Profil Tiap Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "655c2bff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Profil rata-rata skor tiap mata kuliah per cluster\n",
+    "cluster_profile = df.groupby('cluster')[['avg_fisika','avg_kimia','avg_biologi']].mean()\n",
+    "cluster_profile.plot(kind='bar')\n",
+    "plt.ylabel('Rata-rata Skor')\n",
+    "plt.title('Profil Cluster berdasarkan Mata Kuliah')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89e96060",
+   "metadata": {},
+   "source": [
+    "## Distribusi Cluster menurut Status Pernah Mengambil Mata Kuliah"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82cd8533",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Distribusi cluster berdasarkan status pernah mengambil mata kuliah\n",
+    "for course in ['Fisika','Kimia','Biologi']:\n",
+    "    col = f'Pernah_{course}'\n",
+    "    ctab = pd.crosstab(df[col], df['cluster'])\n",
+    "    ctab.plot(kind='bar', stacked=True)\n",
+    "    plt.title(f'Distribusi Cluster vs {col}')\n",
+    "    plt.xlabel(col)\n",
+    "    plt.ylabel('Jumlah')\n",
+    "    plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83c5433e",
+   "metadata": {},
+   "source": [
+    "## Boxplot Sentimen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a37e9ee5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Boxplot sentimen per Program Studi dan Angkatan\n",
+    "plt.figure(figsize=(12,6))\n",
+    "sns.boxplot(x='Program Studi', y='sentiment', data=df)\n",
+    "plt.title('Sebaran Sentimen per Program Studi')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=(12,6))\n",
+    "sns.boxplot(x='Angkatan', y='sentiment', data=df)\n",
+    "plt.title('Sebaran Sentimen per Angkatan')\n",
+    "plt.show()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- fix dataset path in *explorasi_visualisasi.ipynb*
- add correlation heatmap of Likert questions
- visualize average subject scores per cluster
- show cluster distribution by prior courses taken
- add boxplots of sentiment per program and cohort

## Testing
- `pip install pandas matplotlib seaborn nbformat` *(passed)*
- `python3 - <<'PY'
import pandas as pd
pd.read_csv('cluster_sentiment_output.csv')
print('Data loaded')
PY` *(passed)*

------
https://chatgpt.com/codex/tasks/task_b_68496a34e2ac8333ab2fb6f5a1d6b806